### PR TITLE
removed \space

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,6 @@
 FROM maven:3.6.1-jdk-8-slim
 WORKDIR /app
 COPY . .
-RUN mvn package && \ mv target/worker-jar-with-dependencies.jar /run/worker.jar && rm -rf /app/*
+RUN mvn package && \
+    mv target/worker-jar-with-dependencies.jar /run/worker.jar && rm -rf /app/*
 CMD java -jar /run/worker.jar


### PR DESCRIPTION
Had an extra space after the '\' with second RUN command. Removed and allowed for docker image build. 
Curse you spaces!!